### PR TITLE
docs: add factory-improvement documentation practice

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,13 +25,19 @@ See README.md for complete setup instructions including:
 **Key Principles:**
 - **Human intervention = factory bug** - If a human needs to step in, that's a bug in the factory itself
 - **Fix the factory, not the symptom** - When intervening, always ask: "How can I prevent needing to intervene for this type of issue again?"
+- **Workflow fixes over one-off fixes** - ALWAYS prefer updating workflows/agents to handle issues automatically rather than fixing issues manually. A one-off fix helps once; a workflow fix helps forever.
 - **Visibility enables autonomy** - Agents must post progress updates to issues so humans can monitor without intervening
 - **Self-healing over manual fixes** - CI failures auto-create issues, agents auto-fix them
+- **Immediate triggers over polling** - When possible, use webhooks/events (e.g., `push` to main) to trigger actions immediately rather than waiting for scheduled polls
 
 **When you (human or Claude) intervene:**
 1. Fix the immediate issue
 2. Update the relevant agent workflow to handle this case autonomously next time
 3. Document the improvement in this file
+4. **Update the template repo** - If this is a derived project, make a generic version of the fix in [claude-software-factory-template](https://github.com/jeremymatthewwerner/claude-software-factory-template) so other projects benefit
+5. **Create a closed issue documenting the fix** - File an issue with `factory-improvement` label describing the problem, root cause, and solution. Close it immediately with a reference to the fixing PR. This creates a searchable audit trail of factory learnings.
+
+> **Why document as issues?** Workflow fixes often happen in interactive Claude sessions. Without explicit documentation, these learnings are lost in chat history. A closed issue with `factory-improvement` label creates a permanent, searchable record that benefits future debugging and onboarding.
 
 ## Decision-Making Autonomy (CRITICAL)
 
@@ -171,6 +177,7 @@ All bugs AND tasks must be tracked via GitHub Issues for audit history.
 - `ai-ready` - Ready for autonomous agent
 - `needs-principal-engineer` - Escalated to PE (Code Agent stuck)
 - `needs-human` - Requires human intervention (PE escalated)
+- `factory-improvement` - Documents a workflow/factory fix (closed immediately with details)
 - `priority-high`, `priority-medium`, `priority-low`
 
 ## Autonomous Agents

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ gh label create "priority-low" --color "0E8A16" --description "Low priority"
 gh label create "P0" --color "B60205" --description "Critical - system down"
 gh label create "P1" --color "D93F0B" --description "High - blocks functionality"
 gh label create "P2" --color "FBCA04" --description "Medium - optimization/cleanup"
+gh label create "factory-improvement" --color "1D76DB" --description "Documents a workflow/factory fix"
 ```
 
 #### 2.2 Configure Repository Secrets


### PR DESCRIPTION
## Summary

This PR adds guidance for documenting workflow/factory fixes as closed issues with the `factory-improvement` label. This ensures that valuable learnings from fixing factory issues are persisted in the repository as a searchable audit trail, rather than being lost in chat histories.

### Changes:

**CLAUDE.md:**
- Added "Workflow fixes over one-off fixes" principle
- Added "Immediate triggers over polling" principle  
- Added step 4: Update template repo with generic fixes
- Added step 5: Create closed issue with `factory-improvement` label describing problem, root cause, and solution
- Added explanation of why documenting as issues matters
- Added `factory-improvement` label to Issue Labels section

**README.md:**
- Added `gh label create "factory-improvement"` command to label setup

## Why This Matters

When humans or Claude Code sessions fix workflow/factory issues, those learnings often happen in interactive sessions. Without explicit documentation, these insights are lost in chat history. A closed issue with `factory-improvement` label creates a permanent, searchable record that benefits:
- Future debugging (search closed issues to find similar problems)
- Onboarding (new maintainers can learn from past fixes)
- Template improvements (identify patterns across projects)

## Test Plan

- [x] CLAUDE.md updated with intervention steps 4 and 5
- [x] CLAUDE.md has factory-improvement label in Issue Labels
- [x] README.md has factory-improvement label create command