### PR TITLE
fix(factory-manager): use negation for schedule matching

### DIFF
--- a/.github/workflows/factory-manager.yml
+++ b/.github/workflows/factory-manager.yml
@@ -39,7 +39,7 @@ jobs:
   # ===========================================
   health-check:
     if: |
-      (github.event_name == 'schedule' && github.event.schedule == '*/5 * * * *') ||
+      (github.event_name == 'schedule' && github.event.schedule != '0 6 * * 1') ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'full-health-check')
     runs-on: ubuntu-latest
     timeout-minutes: 15


### PR DESCRIPTION
## Summary
Fix Factory Manager scheduled health checks being skipped.

## Problem
The exact cron string comparison `github.event.schedule == '*/5 * * * *'` was failing.

## Solution
Changed to negation-based matching - health check runs for any schedule that is NOT the weekly report.