### PR TITLE
fix(factory): prevent Code Agent recursive triggers on closed issues

### DIFF
--- a/.github/workflows/bug-fix.yml
+++ b/.github/workflows/bug-fix.yml
@@ -100,11 +100,13 @@ jobs:
 
   fix:
     # Triggers on:
-    # 1. Comment containing @code or @claude on an issue
+    # 1. Comment containing @code or @claude on an issue (from a human, not a bot)
     # 2. ANY comment on an issue with status:awaiting-bot label (human responded)
     # 3. Manual workflow dispatch
     # SKIP if: needs-human label is present (escalated, requires human intervention)
     # SKIP if: factory-meta label is present (handled by Factory Manager only)
+    # SKIP if: issue is closed (prevents recursive triggers on closed canary test issues)
+    # SKIP if: comment is from a bot (prevents self-triggering loops)
     # NOTE: Legacy ai-ready label triggers removed - use @code mention instead
     if: |
       !contains(github.event.issue.labels.*.name, 'needs-human') &&
@@ -112,6 +114,10 @@ jobs:
       (github.event_name == 'workflow_dispatch' ||
        (github.event_name == 'issue_comment' &&
         !github.event.issue.pull_request &&
+        github.event.issue.state != 'closed' &&
+        github.event.comment.user.type != 'Bot' &&
+        github.event.comment.user.login != 'github-actions' &&
+        github.event.comment.user.login != 'github-actions[bot]' &&
         (contains(github.event.comment.body, '@code') ||
          contains(github.event.comment.body, '@Code') ||
          contains(github.event.comment.body, '@claude') ||


### PR DESCRIPTION
## Summary
- Adds guards to prevent Code Agent from triggering on closed issues
- Adds guards to prevent self-triggering loops from bot comments
- Prevents recursive workflows that occurred in issue #22

## Changes
Added to the `fix:` job condition in `bug-fix.yml`:
1. `github.event.issue.state != 'closed'` - Skip closed issues
2. `github.event.comment.user.type != 'Bot'` - Skip bot comments
3. `github.event.comment.user.login != 'github-actions'` - Skip github-actions
4. `github.event.comment.user.login != 'github-actions[bot]'` - Skip github-actions[bot]

## Root Cause Analysis
Issue #22 showed the Code Agent kept responding to its own comments on closed canary test issues. The '@claude' pattern in "Responding to @claude[bot]" triggered new workflow runs, creating an infinite loop.

## Test Plan
- [ ] Verify closed issues no longer trigger Code Agent
- [ ] Verify bot comments don't trigger Code Agent
- [ ] Verify human comments with @code still trigger correctly

Relates to #23
Relates to #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)