### PR TITLE
ci(deploy): add slack-bot service to CI/CD pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend }}
+      slack_bot: ${{ steps.filter.outputs.slack_bot }}
       e2e: ${{ steps.filter.outputs.e2e }}
       docs_only: ${{ steps.filter.outputs.docs_only }}
     steps:
@@ -34,6 +35,8 @@ jobs:
               - 'backend/**'
             frontend:
               - 'frontend/**'
+            slack_bot:
+              - 'services/slack-bot/**'
             e2e:
               - 'backend/**'
               - 'frontend/**'
@@ -43,6 +46,7 @@ jobs:
               - '.claude/agents/**/*.md'
               - '!backend/**/*.md'  # Exclude backend docs (may affect tests)
               - '!frontend/**/*.md'  # Exclude frontend docs (may affect tests)
+              - '!services/**/*.md'  # Exclude service docs
             # Note: workflow-only changes don't trigger e2e - app code unchanged
 
   # Fast-track documentation-only changes
@@ -307,12 +311,13 @@ jobs:
     # Skip for docs-only changes since no app code changed
     # E2E is skipped on main (already passed on PR) so we don't check it here
     # always() ensures condition is evaluated even when jobs are skipped
+    # Also run for slack-bot changes (no unit tests, just deploy)
     if: |
       always() &&
       github.ref == 'refs/heads/main' &&
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch') &&
-      (needs.changes.outputs.e2e == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch') &&
-      !(needs.changes.outputs.docs_only == 'true' && needs.changes.outputs.backend != 'true' && needs.changes.outputs.frontend != 'true') &&
+      (needs.changes.outputs.e2e == 'true' || needs.changes.outputs.slack_bot == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch') &&
+      !(needs.changes.outputs.docs_only == 'true' && needs.changes.outputs.backend != 'true' && needs.changes.outputs.frontend != 'true' && needs.changes.outputs.slack_bot != 'true') &&
       needs.backend.result != 'failure' &&
       needs.frontend.result != 'failure'
     permissions:
@@ -382,7 +387,7 @@ jobs:
   deploy:
     name: Deploy to Railway
     runs-on: ubuntu-latest
-    needs: [build-and-push]
+    needs: [changes, build-and-push]
     # always() needed because upstream jobs use always()
     if: |
       always() &&
@@ -403,6 +408,12 @@ jobs:
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN_SW_FACTORY }}
         run: railway redeploy --service frontend --yes
+
+      - name: Redeploy Slack Bot
+        if: needs.changes.outputs.slack_bot == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN_SW_FACTORY }}
+        run: railway redeploy --service slack-bot --yes
 
   smoke-test:
     name: Production Smoke Test


### PR DESCRIPTION
## Summary

- Adds slack-bot path filter to detect changes in `services/slack-bot/`
- Updates build-and-push condition to trigger for slack-bot changes
- Adds Redeploy Slack Bot step to deploy job (conditional on changes)
- Excludes `services/**/*.md` from docs_only filter to ensure code changes are not misclassified

## Changes Made

### 1. Path Filters
Added `slack_bot` filter that detects changes to `services/slack-bot/**`

### 2. Build Condition
Updated `build-and-push` job condition to:
- Trigger when slack-bot changes are detected
- Not classify slack-bot changes as "docs only"

### 3. Deploy Step
Added conditional slack-bot deployment step that runs when:
- slack-bot files changed, OR
- Manual/repository dispatch trigger

## Test Plan

- [x] Verify workflow syntax is valid
- [ ] After merge, push a change to `services/slack-bot/` and verify deployment triggers
- [ ] Verify the health endpoint shows updated `test_deployment` marker

## Relates to #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)