### PR TITLE
fix(slack-bot): fix StatusAnimator key mismatch causing missing responses

### DIFF
--- a/services/slack-bot/src/utils/status-animator.ts
+++ b/services/slack-bot/src/utils/status-animator.ts
@@ -235,7 +235,7 @@ export class StatusAnimator {
 
       logger.debug('Status animator started', { key, phases: phases.length });
 
-      return response.ts;
+      return key; // Return the key used to store the tracker, NOT response.ts
     } catch (error) {
       logger.error('Failed to start status animator', { error, key });
       throw error;
@@ -307,9 +307,10 @@ export class StatusAnimator {
     }
 
     try {
-      // FIXED: Instead of updating the status message, post final result as NEW message
-      // This preserves the animated status history and adds the final result
-      const threadTs = key.split('-').pop(); // Extract threadTs from key format "channel-threadTs"
+      // Post final result as NEW message, preserving the animated status history
+      // Key format is "channel-threadTs", extract threadTs after first hyphen
+      const hyphenIndex = key.indexOf('-');
+      const threadTs = hyphenIndex > 0 ? key.substring(hyphenIndex + 1) : key;
       
       await client.chat.postMessage({
         channel,


### PR DESCRIPTION
## Bug Fix

The StatusAnimator.start() method was returning response.ts (message timestamp) but the tracker was stored using key (channel-threadTs format). This caused complete() to fail finding the tracker and silently skip posting the final response.

**Root cause:** Key format mismatch between storage and lookup.

**Fix:**
- Changed start() to return `key` instead of `response.ts`
- Made threadTs extraction in complete() more robust using indexOf

This should restore actual AI responses appearing in Slack threads.