### PR TITLE
fix(factory): use uv sync --extra dev for optional dependencies

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Install backend dependencies
         working-directory: backend
-        run: uv sync --group dev
+        run: uv sync --extra dev
 
       - name: Install frontend dependencies
         working-directory: frontend


### PR DESCRIPTION
## Summary
- Fix QA Agent workflow failure by using `--extra dev` instead of `--group dev`

## Problem
The QA Agent workflow was failing with:
```
error: Group `dev` is not defined in the project's `dependency-groups` table
```

This happened because `uv sync --group dev` expects the modern `[dependency-groups]` format, but `backend/pyproject.toml` uses the older `[project.optional-dependencies]` format.

## Solution
Changed `uv sync --group dev` to `uv sync --extra dev` which correctly handles `[project.optional-dependencies]`.

## Test plan
- [ ] QA Agent workflow should run successfully on next schedule (2am UTC)
- [ ] Can verify by manually triggering `workflow_dispatch` on qa.yml

Relates to #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)