### PR TITLE
fix(factory): add hatchling wheel packages config for QA Agent

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -26,6 +26,9 @@ dev = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.wheel]
+packages = ["app"]
+
 [tool.ruff]
 target-version = "py311"
 line-length = 100


### PR DESCRIPTION
## Summary
- Fixes QA Agent workflow failures caused by missing hatchling wheel configuration
- The backend pyproject.toml was missing `[tool.hatch.build.targets.wheel]` section
- Hatchling was looking for `software_factory_backend/` directory but source is in `app/`

## Root Cause
The QA Agent has been failing for 5 consecutive days with:
```
ValueError: Unable to determine which files to ship inside the wheel...
The most likely cause of this is that there is no directory that matches 
the name of your project (software_factory_backend).
```

## Fix
Added explicit package configuration:
```toml
[tool.hatch.build.targets.wheel]
packages = ["app"]
```

## Test plan
- [ ] QA Agent workflow should pass on next scheduled run (2am UTC)
- [ ] `uv sync --extra dev` should work in backend directory

Relates to #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)