### PR TITLE
fix(factory): use uv sync --extra dev for optional dependencies in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
         run: uv python install 3.11
 
       - name: Install dependencies
-        run: uv sync --group dev
+        run: uv sync --extra dev
 
       - name: Lint
         run: uv run ruff check .

--- a/.github/workflows/ci.yml.example
+++ b/.github/workflows/ci.yml.example
@@ -52,7 +52,7 @@ jobs:
         run: uv python install 3.11
 
       - name: Install dependencies
-        run: uv sync --group dev
+        run: uv sync --extra dev
 
       - name: Lint
         run: uv run ruff check .


### PR DESCRIPTION
## Summary
- Fixes `ci.yml` line 109: changes `uv sync --group dev` to `uv sync --extra dev`
- Also fixes the same issue in `ci.yml.example`

## Why
The backend `pyproject.toml` uses `[project.optional-dependencies]` which requires the `--extra` flag, not `--group` (which is for `[dependency-groups]`).

PR #59 fixed this in `qa.yml` but missed `ci.yml` and `ci.yml.example`.

## Context
This is blocking PR #101 which fixes the hatch build config. Both PRs together will unblock the QA Agent.

Relates to #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)